### PR TITLE
Tty slime comm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "om/src/api/om-slime/slime"]
+	path = om/src/api/om-slime/slime
+	url = https://github.com/cac-t-u-s/slime.git

--- a/om/build/build-om.lisp
+++ b/om/build/build-om.lisp
@@ -78,6 +78,8 @@
 
 (load (merge-pathnames "src/api/foreign-interface/foreign-interface" *om-root-directory*))
 
+(load (merge-pathnames "src/api/om-slime/om-slime.lisp" *om-root-directory*))
+
 ;;;=======================================
 ;;;; LOAD EXTERNAL LISP TOOLS
 ;;;=======================================

--- a/om/src/api/om-slime/om-slime.lisp
+++ b/om/src/api/om-slime/om-slime.lisp
@@ -1,0 +1,26 @@
+;============================================================================
+; om#: visual programming language for computer-aided music composition
+; J. Bresson et al., IRCAM (2013-2020)
+; Based on OpenMusic (c) IRCAM / G. Assayag, C. Agon, J. Bresson
+;============================================================================
+;
+;   This program is free software. For information on usage 
+;   and redistribution, see the "LICENSE" file in this distribution.
+;
+;   This program is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+;
+;============================================================================
+; File author: A. Vinjar
+;============================================================================
+
+;;; Load swank w. contribs.  The actual call to start the swank server is in a
+;;; function added to om#'s *init-func-list* (controllable by user-prefs) inside
+;;; environment/om-swank.lisp.
+
+(load (merge-pathnames "slime/swank-loader.lisp" *load-pathname*))
+
+(setq swank-loader::*fasl-directory* (merge-pathnames "fasl/" *load-pathname*))
+
+(swank-loader:init :setup nil :load-contribs t)

--- a/om/src/kernel/environment/om-preferences.lisp
+++ b/om/src/kernel/environment/om-preferences.lisp
@@ -242,6 +242,27 @@
 ;;; special case: sets a behavior from the OM-API
 ;(defmethod set-pref-in-module :after ((module (eql :general)) (key (:eql :listener-on-top)) val) (setf om-lisp::*listener-on-top* val))
 ;;; not anymore (initarg in the constructor)
+(add-preference-section 
+ :general "Patch Execution" 
+ nil
+ '(:catch-errors 
+   :debug 
+   :auto-ev-once-mode
+   ))
+
+(add-preference-section 
+ :general "Lisp REPL" 
+ nil 
+ '(:listener-on-top 
+   :listener-input 
+   :listener-font 
+   :textedit-font 
+   :print-system-output 
+   :om-swank-server 
+   :listener-in-tty
+   ))
+
+
 
 
 

--- a/om/src/kernel/environment/om-swank.lisp
+++ b/om/src/kernel/environment/om-swank.lisp
@@ -1,0 +1,37 @@
+;============================================================================
+; om#: visual programming language for computer-aided music composition
+; J. Bresson et al., IRCAM (2013-2020)
+; Based on OpenMusic (c) IRCAM / G. Assayag, C. Agon, J. Bresson
+;============================================================================
+;
+;   This program is free software. For information on usage 
+;   and redistribution, see the "LICENSE" file in this distribution.
+;
+;   This program is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+;
+;============================================================================
+; File author: A. Vinjar
+;============================================================================
+
+;;; 
+;;; slime/swank I/O om# <-> emacs
+;;;
+;;; This file is to enable preference items to control the swank server running
+;;; inside om#.  Slime/Swank setup is inside src/api/om-slime/om-slime.lisp
+;;; 
+;;; Start swank server to communicate with om# from within Emacs (or other
+;;; pipes).  Default port - 4005 - is used here:
+;;; 
+
+(add-preference :general :om-swank-server "Start Swank server" :bool t
+		"Enable Swank server (in Emacs: 'M-x slime-connect RET RET')"
+		'start-swank-server)
+
+(defun start-swank-server ()    ;hook called after om# init
+  (when (get-pref-value :general :om-swank-server)
+    (swank::init)
+    (swank:create-server)))
+
+(add-om-init-fun 'start-swank-server)

--- a/om/src/kernel/environment/om-swank.lisp
+++ b/om/src/kernel/environment/om-swank.lisp
@@ -26,7 +26,7 @@
 ;;; 
 
 (add-preference :general :om-swank-server "Start Swank server" :bool t
-		"Enable Swank server (in Emacs: 'M-x slime-connect RET RET')"
+		"Enable Emacs/Slime communication (in Emacs: 'M-x slime-connect RET RET')"
 		'start-swank-server)
 
 (defun start-swank-server ()    ;hook called after om# init

--- a/om/src/kernel/environment/om-tty-listener.lisp
+++ b/om/src/kernel/environment/om-tty-listener.lisp
@@ -1,0 +1,34 @@
+;============================================================================
+; om#: visual programming language for computer-aided music composition
+; J. Bresson et al., IRCAM (2013-2020)
+; Based on OpenMusic (c) IRCAM / G. Assayag, C. Agon, J. Bresson
+;============================================================================
+;
+;   This program is free software. For information on usage 
+;   and redistribution, see the "LICENSE" file in this distribution.
+;
+;   This program is distributed in the hope that it will be useful,
+;   but WITHOUT ANY WARRANTY; without even the implied warranty of
+;   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+;
+;============================================================================
+; File author: A. Vinjar
+;============================================================================
+
+;; Communication with OM through *terminal-io*
+;; 
+;; listener I/O in tty
+;; 
+(add-preference :general :listener-in-tty "Start TTY listener" :bool nil
+		"Start (Stop) a listener in the startup shell"
+		'start-stop-tty-listener)
+
+(defun start-stop-tty-listener (&optional force)
+  (if (or force (get-pref-value :general :listener-in-tty))
+      (lispworks:start-tty-listener)
+      (progn
+	(format *terminal-io* "...quitting TTY Listener, bye...~%")
+	(mp:process-terminate (mp:get-process "TTY Listener")))))
+
+(add-om-init-fun 'start-stop-tty-listener)
+

--- a/om/src/kernel/kernel-files.lisp
+++ b/om/src/kernel/kernel-files.lisp
@@ -64,7 +64,8 @@
         "environment/om-package"
         "environment/om-library"
         "environment/om-workspace" 
-        "environment/om-function-reference" 
+        "environment/om-function-reference"
+	"environment/om-swank"
         
         "windows/om-windows"
         "windows/om-main-window"

--- a/om/src/kernel/kernel-files.lisp
+++ b/om/src/kernel/kernel-files.lisp
@@ -66,6 +66,7 @@
         "environment/om-workspace" 
         "environment/om-function-reference"
 	"environment/om-swank"
+	"environment/om-tty-listener"
         
         "windows/om-windows"
         "windows/om-main-window"


### PR DESCRIPTION
enable support for using om# with slime in emacs

om# needs it's own slime, because compile-file is missing in releases

as well, a start-tty-listener (from the prefs) to have a repl running in the shell where om# was started.

With these additions, the current preferences (in the "general" tab) gets quite messy -> tidy, find better wording, documentation