### PR TITLE
Fix search folder access for global abstractions

### DIFF
--- a/src/kernel/patch/om-patch-editor.lisp
+++ b/src/kernel/patch/om-patch-editor.lisp
@@ -1378,9 +1378,9 @@
                        (pathname-name local-restored-path)
                        (om-make-pathname :directory local-restored-path)))
         ))
-    
-    (unless (probe-file doc-path)
       
+    (unless (and doc-path (probe-file doc-path))
+
       ;;; try with the search folder
       (let ((search-matches (remove nil 
                                     (loop for type in abs-types collect


### PR DESCRIPTION
Just a small fix, doc-path gets set to nil when there was no local match, which was causing an error when probe-file was called on it.

Slight uncleanliness on this commit because of the apparent added/erased lines, which is because of some funny whitespace changes  ... line breaks didn't actually change.