### PR TITLE
Fix markers in sequencer

### DIFF
--- a/src/kernel/patch/om-box.lisp
+++ b/src/kernel/patch/om-box.lisp
@@ -103,7 +103,7 @@
      (:text-font "Text font" :font-or-nil text-font (:appearance :box-font)) 
      (:align "Text align" (:left :center :right :default) text-align (:appearance :box-align))
      )
-    ("Structure" ;;; category
+    ("Sequencer" ;;; category
      (:group-id "Group/Track" (:none 1 2 3 4 5 6 7 8) group-id)
      )))
 

--- a/src/kernel/patch/om-boxobject.lisp
+++ b/src/kernel/patch/om-boxobject.lisp
@@ -459,14 +459,24 @@
 (defmethod editor-ed-params-properties ((self t)) nil)
 
 (defmethod get-properties-list ((self OMBoxEditCall))
-  (let ((properties (call-next-method)))  ;; (append (hide-property (call-next-method) '(:icon :align)))))
-    (add-properties properties "Appearance" 
-                    (append 
-                     `((:name "Name" :string name)
-                       (:display "View (m)" ,(display-modes-for-object (car (value self))) display)
-                       (:showname "Show name (n)" :bool show-name))
-                     (when (play-obj? (car (value self)))
-                       '((:show-markers "Show markers" :bool show-markers)))))))
+  
+  (let ((properties (add-properties 
+                     (call-next-method) 
+                     "Appearance" 
+                     (append 
+                      `((:name "Name" :string name)
+                        (:display "View (m)" ,(display-modes-for-object (get-box-value self)) display)
+                        (:showname "Show name (n)" :bool show-name))
+                      ))))
+                     
+    (if (play-obj? (get-box-value self))
+        (add-properties 
+         properties 
+         "Sequencer" 
+         '((:show-markers "Show markers" :bool show-markers)))
+      properties)
+      
+    ))
 
 
 (defmethod display-modes-for-object ((self t)) '(:text :hidden))

--- a/src/kernel/play/editor-player.lisp
+++ b/src/kernel/play/editor-player.lisp
@@ -760,7 +760,7 @@
   (setf (onset self) (max 0 (+ (onset self) dt))))
 
 
-(defmethod get-timed-objects-for-graduated-view ((self x-graduated-view))
+(defmethod get-timed-objects-with-markers ((self x-graduated-view))
   "returns a list of timed-object containing markers"
   nil)
 
@@ -795,7 +795,7 @@
 (defmethod get-all-time-markers ((self time-ruler))
   (sort (remove nil (flat (loop for view in (related-views self)
                                 collect
-                                (loop for timed-obj in (get-timed-objects-for-graduated-view view)
+                                (loop for timed-obj in (get-timed-objects-with-markers view)
                                       when (and timed-obj (play-obj? timed-obj)) collect
                                       (if (markers-count-object-onset-p self)
                                           (om+ (get-time-markers timed-obj) (get-onset timed-obj))
@@ -816,7 +816,7 @@
   (let* ((ref-time (pix-to-x self (om-point-x position)))
          (objs (remove nil (flat (loop for rv in (related-views self)
                                        collect
-                                       (get-timed-objects-for-graduated-view rv)))))
+                                       (get-timed-objects-with-markers rv)))))
          (obj-elem-list (loop for obj in objs collect
                               (list obj (get-elements-for-marker
                                          obj  

--- a/src/kernel/play/editor-player.lisp
+++ b/src/kernel/play/editor-player.lisp
@@ -579,7 +579,9 @@
   ((unit :accessor unit :initform :ms :initarg :unit)
    (bottom-p :accessor bottom-p :initform t :initarg :bottom-p) ;bottom-p indicates if the arrow need to be on the top or the bottom (default is on the top)
    (markers-p :accessor markers-p :initform t :initarg :markers-p) ;use or not markers
-   (onset-p :accessor onset-p :initform t :initarg :onset-p) ;use or not onset for markers (maquette vs timeline)
+   (markers-count-object-onset-p 
+    :accessor markers-count-object-onset-p :initform t :initarg :markers-count-object-onset-p
+    :documentation "if T, markers will consider the objet onset for placement (e.g. in maquette)")
    (snap-to-grid :accessor snap-to-grid :initform t :initarg :snap-to-grid)
    (selected-time-markers :accessor selected-time-markers :initform nil)) 
   (:default-initargs :vmin 0))
@@ -795,7 +797,7 @@
                                 collect
                                 (loop for timed-obj in (get-timed-objects-for-graduated-view view)
                                       when (and timed-obj (play-obj? timed-obj)) collect
-                                      (if (onset-p self)
+                                      (if (markers-count-object-onset-p self)
                                           (om+ (get-time-markers timed-obj) (get-onset timed-obj))
                                         (get-time-markers timed-obj))
                                       )))) '<))
@@ -818,7 +820,7 @@
          (obj-elem-list (loop for obj in objs collect
                               (list obj (get-elements-for-marker
                                          obj  
-                                         (if (onset-p self) (om- marker (get-onset obj)) marker))))))
+                                         (if (markers-count-object-onset-p self) (om- marker (get-onset obj)) marker))))))
     (om-init-temp-graphics-motion 
      self position nil 
      :min-move 4

--- a/src/kernel/play/editor-player.lisp
+++ b/src/kernel/play/editor-player.lisp
@@ -796,7 +796,7 @@
   (sort (remove nil (flat (loop for view in (related-views self)
                                 collect
                                 (loop for timed-obj in (get-timed-objects-with-markers view)
-                                      when (and timed-obj (play-obj? timed-obj)) collect
+                                      collect
                                       (if (markers-count-object-onset-p self)
                                           (om+ (get-time-markers timed-obj) (get-onset timed-obj))
                                         (get-time-markers timed-obj))

--- a/src/kernel/play/editor-player.lisp
+++ b/src/kernel/play/editor-player.lisp
@@ -813,14 +813,22 @@
 
 
 (defmethod translate-from-marker-action ((self time-ruler) marker position)
+
   (let* ((ref-time (pix-to-x self (om-point-x position)))
          (objs (remove nil (flat (loop for rv in (related-views self)
                                        collect
                                        (get-timed-objects-with-markers rv)))))
-         (obj-elem-list (loop for obj in objs collect
-                              (list obj (get-elements-for-marker
-                                         obj  
-                                         (if (markers-count-object-onset-p self) (om- marker (get-onset obj)) marker))))))
+         (obj-elem-list 
+          (remove nil
+                  (loop for obj in objs collect
+                        (let ((matching-elements 
+                               (get-elements-for-marker
+                                obj  
+                                (if (markers-count-object-onset-p self) 
+                                    (om- marker (get-onset obj)) marker))))
+                          (when matching-elements
+                            (list obj matching-elements)))))))
+
     (om-init-temp-graphics-motion 
      self position nil 
      :min-move 4

--- a/src/kernel/play/editor-player.lisp
+++ b/src/kernel/play/editor-player.lisp
@@ -744,6 +744,20 @@
 ;1) Have a child class of timed-objects and overload the get-time-markers method
 ;2) Have a child class of x-graduated view and overload the following methods
 
+(defmethod get-time-markers ((self t)) 
+  "returns the list of time markers in an object"
+  nil)
+
+(defmethod get-elements-for-marker ((self timed-object) marker)
+  "returns a list of one or more elements in the object that correspond to the marker"
+  nil)
+
+(defmethod translate-elements-from-time-marker ((self timed-object) elems dt)
+  "translates elements from a time marker with dt"
+  (declare (ignore elems))
+  (setf (onset self) (max 0 (+ (onset self) dt))))
+
+
 (defmethod get-timed-objects-for-graduated-view ((self x-graduated-view))
   "returns a list of timed-object containing markers"
   nil)

--- a/src/kernel/play/timed-object.lisp
+++ b/src/kernel/play/timed-object.lisp
@@ -28,25 +28,6 @@
 ;;; redefine for subclasses
 (defmethod get-obj-dur ((self timed-object)) 1)
 
-;;; some objects just have no time markers ?
-(defmethod get-time-markers ((self t)) nil)
-
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
-(defmethod get-time-markers ((self timed-object))
-  "returns a list of time markers"
-  (list 0))
-
-
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
-(defmethod get-elements-for-marker ((self timed-object) marker)
-  "returns a list of elements matching the marker"
-  (list nil))
-
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
-(defmethod translate-elements-from-time-marker ((self timed-object) elems dt)
-  "translates elements from a time marker with dt"
-  (setf (onset self) (max 0 (+ (onset self) dt))))
-
 (defmethod set-object-onset ((self timed-object) onset)
   (setf (onset self) onset))
 

--- a/src/packages/basic/bpf-bpc/bpc.lisp
+++ b/src/packages/basic/bpf-bpc/bpc.lisp
@@ -165,15 +165,16 @@ If <x-list> and <y-list> are not of the same length, the last step in the shorte
   (let ((times (or time (time-values-from-points self))))
     (when times
       (loop for p in (point-list self)
-            for time in times do (setf (tpoint-time p) time)))
-    (when time-types
-      (loop for p in (point-list self)
-            for type in time-types do (om-point-set p :type type)))
+            for time in times do (setf (tpoint-time p) time))))
+    
+  (when time-types
+    (loop for p in (point-list self)
+          for type in time-types do (om-point-set p :type type)))
 
-    (setf (slot-value self 'x-points) NIL)
-    (setf (slot-value self 'y-points) NIL)
-    (setf (slot-value self 'times) NIL)
-    (setf (slot-value self 'time-types) NIL)))
+  (setf (slot-value self 'x-points) NIL)
+  (setf (slot-value self 'y-points) NIL)
+  (setf (slot-value self 'times) NIL)
+  (setf (slot-value self 'time-types) NIL))
 
 
 ;;; In BPC all moves are possible

--- a/src/packages/basic/bpf-bpc/bpf.lisp
+++ b/src/packages/basic/bpf-bpc/bpf.lisp
@@ -262,6 +262,17 @@
 (defmethod time-sequence-make-timed-item-at ((self bpf) at)
   (om-make-bpfpoint at (x-transfer self at (decimals self))))
 
+
+;;; redefine this to be a little bit safer wrt floating point errors
+;;; (since BPF can have sub-millisecond time-point values...) 
+(defmethod point-exists-at-time ((self bpf) time)
+  (let* ((fact (expt 10 (decimals self)))
+         (rounded-time (round (* time fact))))
+    (loop for point in (time-sequence-get-timed-item-list self)
+          when (and (= (round (* (item-get-internal-time point) fact)) rounded-time))
+          return point)))
+
+
 ;=======================================
 ;WHEN IN A COLLECTION...
 ;=======================================

--- a/src/packages/basic/bpf-bpc/bpf.lisp
+++ b/src/packages/basic/bpf-bpc/bpf.lisp
@@ -488,6 +488,28 @@
     
     t))
 
+
+(defmethod draw-maquette-mini-view ((self bpf) (box t) x y w h &optional time)
+  (let* ((display-cache (ensure-cache-display-draw box self))
+         (ranges (car display-cache))
+         (x-range (list 0 (nth 1 ranges)))
+         (y-range (list (or (get-edit-param box :display-min) (nth 2 ranges))
+                        (or (get-edit-param box :display-max) (nth 3 ranges)))))
+    
+    (draw-bpf-points-in-rect (cadr display-cache)
+                             (color self) 
+                             (append x-range y-range)
+                             (+ x 2) (+ y 10) (- w 4) (- h 20)
+                             (get-edit-param box :draw-style))
+
+    (om-with-fg-color (om-def-color :gray)
+      (om-with-font (om-def-font :font1 :size 8)
+                    (om-draw-string x (+ y (- h 14)) (number-to-string (nth 0 y-range)))
+                    (om-draw-string x (+ y 10) (number-to-string (nth 1 y-range)))
+                    ))
+    t))
+
+
 (defun conversion-factor-and-offset (min max w delta)
   (let* ((range (- max min))
          (factor (if (zerop range) 1 (/ w range))))

--- a/src/packages/basic/bpf-bpc/bpf.lisp
+++ b/src/packages/basic/bpf-bpc/bpf.lisp
@@ -450,7 +450,7 @@
         maximize (fourth range) into y2
         finally (return (list x1 x2 y1 y2))))
 
-;;; redefined by objects if they have a specific draw/cache strategy
+
 (defmethod get-cache-display-for-draw ((self bpf) box) 
   (list 
    (nice-bpf-range self)
@@ -463,7 +463,6 @@
    ))
 
 
-;;; to be redefined by objects if they have a specific miniview
 (defmethod draw-mini-view ((self bpf) (box t) x y w h &optional time)
   (let* ((display-cache (ensure-cache-display-draw box self))
          (ranges (car display-cache))

--- a/src/packages/basic/bpf-bpc/bpf.lisp
+++ b/src/packages/basic/bpf-bpc/bpf.lisp
@@ -84,6 +84,9 @@
   
 (defmethod additional-class-attributes ((self BPF)) '(decimals color name action interpol))
 
+(defmethod additional-slots-to-copy ((self BPF)) 
+  (append (call-next-method) '(time-types)))
+
 ;;; decimals will be set because it is initarg
 (defmethod initialize-instance ((self bpf) &rest args) 
   (call-next-method)
@@ -173,7 +176,7 @@
 ;    (mapcar #'(lambda (p) (list (/ (om-point-x p) fact) (/ (om-point-y p) fact))) (point-list self)))
 ;  ))
 
-(defmethod set-bpf-points ((self bpf) &key x y z time)
+(defmethod set-bpf-points ((self bpf) &key x y z time time-types)
   (declare (ignore time z))
   (setf (point-list self) (sort 
                            (make-points-from-lists (or x (x-values-from-points self)) ;  (slot-value self 'x-points))
@@ -181,7 +184,12 @@
                                                    (decimals self)
                                                    'om-make-bpfpoint)
                            '< :key 'om-point-x))
-  ;;; maybe check here if there is not duplicate X points and send a warning...
+  ;;; todo?: check here if there is not duplicate X points and send a warning...
+
+  (when time-types
+    (loop for p in (point-list self)
+          for type in time-types do (om-point-set p :type type)))
+    
   (setf (slot-value self 'x-points) NIL) 
   (setf (slot-value self 'y-points) NIL))
 
@@ -200,7 +208,9 @@
 (defmethod init-bpf-points  ((self bpf))
   (set-bpf-points self
                   :x (slot-value self 'x-points)
-                  :y (slot-value self 'y-points)))
+                  :y (slot-value self 'y-points)
+                  :time-types (slot-value self 'time-types))
+  )
 
 (defmethod change-precision ((self bpf) decimals)
   (setf (decimals self) decimals)

--- a/src/packages/basic/time-sequence/time-sequence.lisp
+++ b/src/packages/basic/time-sequence/time-sequence.lisp
@@ -60,7 +60,7 @@
 ; - Interpolate output values if interpol is on ?
 
 (defclass time-sequence (timed-object)
-  ((time-types :initform nil :accessor time-types) ; :initarg :time-types) ;; this slot shall probably disappear..
+  ((time-types :initform nil :accessor time-types)
    (duration :initform 0 :accessor duration :initarg :duration)
    (interpol :initform nil :accessor interpol :initarg :interpol)))
 
@@ -217,7 +217,7 @@
 
 
 (defmethod update-time-types-from-tpoint-list ((self time-sequence))
-  (setf (time-types self) 
+  (setf (time-types self)
         (loop for item in (time-sequence-get-timed-item-list self) 
               collect (item-get-type item))))
 

--- a/src/packages/basic/time-sequence/time-sequence.lisp
+++ b/src/packages/basic/time-sequence/time-sequence.lisp
@@ -500,7 +500,7 @@
 (defmethod temporal-translate-points ((self time-sequence) points dt)
   ;if only one point and master then translate as master point
   (if (and (eql (length points) 1) (eql (item-get-type (car points)) :master))
-      (time-stretch-from-master-point self (car points)  dt)
+      (time-stretch-from-master-point self (car points) dt)
      ;otherwise translate normally if possible
     (when (possible-time-translation self points dt)
       (loop for point in points do
@@ -668,22 +668,16 @@
 ;;; TIME MARKERS METHODS
 ;;;=========================================
 
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
 (defmethod get-time-markers ((self time-sequence))
-  "returns a list of time markers"
-  (append (list 0 ) (get-all-master-points-times self)))
+  (cons 0 (get-all-master-points-times self)))
 
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
 (defmethod get-elements-for-marker ((self time-sequence) marker)
-  "returns a list of elements matching the marker"
   (list (point-exists-at-time self marker)))
 
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
 ;;; jb: not sure it is ever needed to redefine it
 (defmethod translate-elements-from-time-marker ((self time-sequence) elems dt)
-  "translates elements from a time marker with dt"
   (when (not (member nil elems))
-      (temporal-translate-points self elems dt)))
+    (temporal-translate-points self elems dt)))
 
 ;;;=========================================
 ;;; LENGTH AND SPEED METHODS

--- a/src/packages/basic/time-sequence/timeline-editor.lisp
+++ b/src/packages/basic/time-sequence/timeline-editor.lisp
@@ -384,14 +384,12 @@
 
 ;;;==========================
 ;;; Time-marker methods
+;;; to redefine by subclasses
 ;;;==========================
 
-;TIME MARKERS : method to redefine by subclasses
 (defmethod get-timed-objects-for-graduated-view ((self om-timeline-view))
-  ;returns a list of timed-object to retrieve their markers
   (list (editor-get-time-sequence (container-editor (editor self)) (id self))))
 
-;TIME MARKERS method to redefine by subclasses
 (defmethod select-elements-at-time ((self om-timeline-view) marker-time)
   ;selects the elements with same time than the marker-time
   (let* ((editor (editor self))
@@ -404,7 +402,6 @@
           )))
     (update-to-editor editor self)))
 
-;TIME MARKERS
 (defmethod clear-editor-selection ((self timeline-editor))
   (set-selection self nil)
   (set-selected-timelines self nil))

--- a/src/packages/basic/time-sequence/timeline-editor.lisp
+++ b/src/packages/basic/time-sequence/timeline-editor.lisp
@@ -388,7 +388,7 @@
 ;;; to redefine by subclasses
 ;;;==========================
 
-(defmethod get-timed-objects-for-graduated-view ((self om-timeline-view))
+(defmethod get-timed-objects-with-markers ((self om-timeline-view))
   (list (editor-get-time-sequence (container-editor (editor self)) (id self))))
 
 (defmethod select-elements-at-time ((self om-timeline-view) marker-time)

--- a/src/packages/basic/time-sequence/timeline-editor.lisp
+++ b/src/packages/basic/time-sequence/timeline-editor.lisp
@@ -228,7 +228,8 @@
          (main-panel (get-g-component self :main-panel))
          (time-ruler (om-make-view 'time-ruler  :size (omp nil 20) 
                                    :unit :ms :bg-color (om-def-color :white) :bottom-p nil 
-                                   :snap-to-grid (snap-to-grid self) :onset-p nil))
+                                   :snap-to-grid (snap-to-grid self) 
+                                   :markers-count-object-onset-p nil))
          (timeline-views nil)
          (left-item-w 0)
          (foldable-containers nil))

--- a/src/packages/maquette/maquette-editor.lisp
+++ b/src/packages/maquette/maquette-editor.lisp
@@ -773,7 +773,8 @@
 ;;;========================
 
 (defmethod get-timed-objects-for-graduated-view ((self sequencer-track-view))
-  (get-track-boxes (get-obj-to-play (editor self)) (num self)))
+  (remove-if-not #'show-markers 
+                 (get-track-boxes (get-obj-to-play (editor self)) (num self))))
 
 (defmethod select-elements-at-time ((self sequencer-track-view) marker-time)
   (let* ((editor (editor (om-view-window self)))

--- a/src/packages/maquette/maquette-editor.lisp
+++ b/src/packages/maquette/maquette-editor.lisp
@@ -769,25 +769,17 @@
     (call-next-method)))
 
 ;;;========================
-;;; TIME MARKERS
+;;; TIME MARKERS API
 ;;;========================
 
-;TIME MARKERS : method to redefine by subclasses
-;(defmethod get-timed-objects-for-graduated-view ((self sequencer-track-view))
-;  "returns a list of timed-object to retrieve their markers"
-;  (mapcar 'get-box-value (nth (num self) (tracks (get-obj-to-play (editor self))))))
-
 (defmethod get-timed-objects-for-graduated-view ((self sequencer-track-view))
-  "returns a list of timed-object to retrieve their markers"
   (get-track-boxes (get-obj-to-play (editor self)) (num self)))
 
-;TIME MARKERS method to redefine by subclasses
 (defmethod select-elements-at-time ((self sequencer-track-view) marker-time)
-  "selects the elements with same time than the marker-time"
-   (let* ((editor (editor (om-view-window self)))
-          (box (box-at-pos editor marker-time (num self))))
-     (when box (select-box box t))
-     (update-to-editor editor self)))
+  (let* ((editor (editor (om-view-window self)))
+         (box (box-at-pos editor marker-time (num self))))
+    (when box (select-box box t))
+    (update-to-editor editor self)))
 
 ;;==============================
 ;; MARKER API SPECIAL MAQUETTE
@@ -802,12 +794,10 @@
     (contextual-update self (container self))))
 
 (defmethod get-elements-for-marker ((self OMBox) marker)
-  "returns a list of elements matching the marker"
   (when (get-box-value self)
     (get-elements-for-marker (get-box-value self) marker)))
 
 (defmethod get-time-markers ((self OMBox))
-  "returns a list of time markers"
   (when (and (get-box-value self) (show-markers self))
     (get-time-markers (get-box-value self))))
 

--- a/src/packages/maquette/maquette-editor.lisp
+++ b/src/packages/maquette/maquette-editor.lisp
@@ -772,7 +772,7 @@
 ;;; TIME MARKERS API
 ;;;========================
 
-(defmethod get-timed-objects-for-graduated-view ((self sequencer-track-view))
+(defmethod get-timed-objects-with-markers ((self sequencer-track-view))
   (remove-if-not #'show-markers 
                  (get-track-boxes (get-obj-to-play (editor self)) (num self))))
 

--- a/src/packages/maquette/maquette-editor.lisp
+++ b/src/packages/maquette/maquette-editor.lisp
@@ -793,16 +793,6 @@
     (reset-cache-display self)
     (contextual-update self (container self))))
 
-(defmethod get-elements-for-marker ((self OMBox) marker)
-  (when (get-box-value self)
-    (get-elements-for-marker (get-box-value self) marker)))
-
-(defmethod get-time-markers ((self OMBox))
-  (when (and (get-box-value self) (show-markers self))
-    (get-time-markers (get-box-value self))))
-
-
-
 ;;;========================
 ;;; INSPECTOR IN MAQUETTE...
 ;;;========================

--- a/src/packages/maquette/maquette-editor.lisp
+++ b/src/packages/maquette/maquette-editor.lisp
@@ -792,7 +792,10 @@
     (with-schedulable-object (container self)
                              (translate-elements-from-time-marker (get-obj-to-play self) elems dt))
     (reset-cache-display self)
-    (contextual-update self (container self))))
+    (contextual-update self (container self))
+    (when (editor self)
+      (update-to-editor (editor self) self))
+    ))
 
 ;;;========================
 ;;; INSPECTOR IN MAQUETTE...

--- a/src/packages/maquette/maquette-editor.lisp
+++ b/src/packages/maquette/maquette-editor.lisp
@@ -617,7 +617,8 @@
     (om-draw-rect x y w h :fill nil))
   (om-with-fg-color (om-def-color :white)
     (om-draw-string (+ x 2) (+ y h -2) (number-to-string (get-box-onset self)))))
-    
+
+
 (defmethod draw-temporal-box ((self OMBoxPatch) view x y w h &optional (time 0))
   (call-next-method)
 
@@ -644,7 +645,8 @@
   
   (draw-patch-icon self x y)
   (draw-eval-buttons view self x y x 12)
-
+  (draw-temporal-box-name self view x y w h)
+  
   (when (find-if 'reactive (outputs self))
     (om-draw-rect x y w h :line 2 :color (om-def-color :dark-red))) 
   
@@ -654,6 +656,7 @@
         (om-draw-dashed-line x (/ h 2) 
                              (- x (dx-to-dpix view (pre-delay self))) (/ h 2)))))
 
+
 (defmethod draw-temporal-box ((self omboxeditcall) view x y w h &optional (time 0))
   (call-next-method)
   (case (display self)  
@@ -662,8 +665,8 @@
     (:hidden  (om-with-font (om-def-font :font1 :face "arial" :size 18 :style '(:bold))
                           (om-with-fg-color (om-make-color 0.6 0.6 0.6 0.5)
                             (om-draw-string (+ x 10) (max 22 (+ 6 (/ h 2))) 
-                                            (string-upcase (type-of (get-box-value self)))))))))
-
+                                            (string-upcase (type-of (get-box-value self))))))))
+  (draw-temporal-box-name self view x y w h))
 
 
 (defmethod draw-temporal-box-name ((self OMBox) view x y w h)

--- a/src/packages/maquette/maquette-editor.lisp
+++ b/src/packages/maquette/maquette-editor.lisp
@@ -1069,6 +1069,15 @@ CMD-click to add boxes. Play contents, etc.
     ))
 
 
+(defmethod editor-invalidate-views ((editor maquette-editor))
+  (mapc #'om-invalidate-view 
+        (list 
+         (get-g-component editor :main-maq-view)
+         (get-g-component editor :ctrl-view)
+         (get-g-component editor :bottom-view)
+         )))
+
+
 (defun set-main-maquette-view (editor mode)
   (setf (view-mode editor) mode)
   (om-remove-all-subviews (get-g-component editor :main-maq-view))

--- a/src/packages/maquette/maquette-editor.lisp
+++ b/src/packages/maquette/maquette-editor.lisp
@@ -665,6 +665,27 @@
                                             (string-upcase (type-of (get-box-value self)))))))))
 
 
+
+(defmethod draw-temporal-box-name ((self OMBox) view x y w h)
+
+  (let ((name (and (show-name self) 
+                   (or (name self) (default-name (get-box-value self)))))
+        (font (box-draw-font self)))
+
+    (when name
+      (om-with-clip-rect view x y w h
+        (multiple-value-bind (tw th) (om-string-size name font)
+          (declare (ignore th))
+          (om-with-fg-color (box-draw-text-color self)
+            (om-with-font 
+             font
+             (om-draw-string (- (+ x w) tw 4) (- (+ y h) 4)
+                             name 
+                             :selected nil 
+                             :wrap (- w 10)
+                             )
+             )))))))
+
 ;;; !! this is a special case : the frame of the object must change
 ;;; + the 'update' reference of the inspector window (= self) becomes the wrong one
 ;;; 1 solution = re-create the inspector if track is changed

--- a/src/packages/maquette/maquette-object.lisp
+++ b/src/packages/maquette/maquette-object.lisp
@@ -406,30 +406,24 @@
 ;;; TIME MARKERS METHODS
 ;;;=========================================
 
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
-(defmethod get-time-markers ((self ommaquette))
-  "returns a list of time markers"
-  (flat (loop for box in (boxes self)
-              collect
-              (get-time-markers box))))
+;;; note: this is not used as long as maquette are 
+;;; not embedded other maquettes
 
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
-(defmethod get-elements-for-marker ((self ommaquette) marker)
-  "returns a list of elements matching the marker if not elements, it retuns "
+(defmethod get-time-markers ((self OMMaquette))
+  (loop for box in (boxes self)
+        append (get-time-markers box)))
+
+(defmethod get-elements-for-marker ((self OMMaquette) marker)
   (loop for box in (boxes self) 
         collect
         (list box (get-elements-for-marker box marker))))
 
-;;;TIME MARKERS TO REDEFINE FOR YOUR SUBCLASS
-(defmethod translate-elements-from-time-marker ((self ommaquette) elems dt)
-  "translates elements from a time marker with dt"
+(defmethod translate-elements-from-time-marker ((self OMMaquette) elems dt)
   (loop for elem in elems
-        do
-        (when (not (member nil (cdr elem)))
-          (temporal-translate-points (car elem) (cdr elem) dt))))
+        do (when (not (member nil (cdr elem)))
+             (temporal-translate-points (car elem) (cdr elem) dt))))
 
   
-
 ;;;=================================
 ;;; PERSISTENCE / OM-SAVE
 ;;;=================================

--- a/src/packages/maquette/maquette-object.lisp
+++ b/src/packages/maquette/maquette-object.lisp
@@ -413,10 +413,18 @@
   (loop for box in (boxes self)
         append (get-time-markers box)))
 
+(defmethod get-time-markers ((self OMBox))
+  (when (and (get-box-value self) (show-markers self))
+    (get-time-markers (get-box-value self))))
+
 (defmethod get-elements-for-marker ((self OMMaquette) marker)
   (loop for box in (boxes self) 
         collect
         (list box (get-elements-for-marker box marker))))
+
+(defmethod get-elements-for-marker ((self OMBox) marker)
+  (when (get-box-value self)
+    (get-elements-for-marker (get-box-value self) marker)))
 
 (defmethod translate-elements-from-time-marker ((self OMMaquette) elems dt)
   (loop for elem in elems

--- a/src/packages/maquette/maquette-object.lisp
+++ b/src/packages/maquette/maquette-object.lisp
@@ -432,6 +432,12 @@
              (temporal-translate-points (car elem) (cdr elem) dt))))
 
   
+(defmethod set-property ((self OMBox) (prop-id (eql :show-markers)) val)
+  (call-next-method)
+  ;;; in order to update the rulers
+  (editor-invalidate-views (editor (container self))))
+
+
 ;;;=================================
 ;;; PERSISTENCE / OM-SAVE
 ;;;=================================

--- a/src/packages/maquette/metric-ruler.lisp
+++ b/src/packages/maquette/metric-ruler.lisp
@@ -52,7 +52,7 @@
 
 
 ;;; Time markers API (not implemented)
-(defmethod get-timed-objects-for-graduated-view ((self metric-ruler)) nil)
+(defmethod get-timed-objects-with-markers ((self metric-ruler)) nil)
 (defmethod select-elements-at-time ((self metric-ruler) marker-time) nil)
 (defmethod clear-editor-selection ((self metric-ruler)) nil)
 

--- a/src/packages/maquette/metric-ruler.lisp
+++ b/src/packages/maquette/metric-ruler.lisp
@@ -51,22 +51,12 @@
     inst))
 
 
-(defmethod get-timed-objects-for-graduated-view ((self metric-ruler))
-  ;returns a list of timed-object to retrieve their markers
-  nil)
-
-;TIME MARKERS method to redefine by subclasses
-(defmethod select-elements-at-time ((self metric-ruler) marker-time)
-  ;selects the elements with same time than the marker-time
-  nil)
-
-;TIME MARKERS
-(defmethod clear-editor-selection ((self metric-ruler))
-  nil)
+;;; Time markers API (not implemented)
+(defmethod get-timed-objects-for-graduated-view ((self metric-ruler)) nil)
+(defmethod select-elements-at-time ((self metric-ruler) marker-time) nil)
+(defmethod clear-editor-selection ((self metric-ruler)) nil)
 
 
-
-        
 (defun update-span (ruler)
   (let ((span (list (v1 ruler) (v2 ruler))))
     (when (not (equal span (previous-span ruler)))


### PR DESCRIPTION
Fixes a number of behaviours of boxes and objects in the sequencer tracks (and elsewhere)
- Show markers in the sequencer tracks
- Edit/drag the markers, and see the change in the object editors
- Fix display of BPFs when they don't start at 0
- Fix copy of master points with BPF copies 
- Show box names in sequencer tracks
- Gather "group/Track" and "Show markers" in a new "Sequencer" section of box properties.