### PR TITLE
No word break comments

### DIFF
--- a/src/kernel/patch/comments.lisp
+++ b/src/kernel/patch/comments.lisp
@@ -291,7 +291,13 @@
 
 (defmethod fit-comment-size ((box OMComment) size &optional fit)
   (let* ((font (box-draw-font box))
-         (contrained-width (max (om-point-x (minimum-size box)) (om-point-x size))))
+         (contrained-width (max 
+                            (om-point-x (minimum-size box)) 
+                            (om-point-x size)
+                            (+ (apply 'max (mapcar #'(lambda (str) 
+                                                       (om-string-size str font))
+                                                   (mapcan 'string-to-list (string-lines-to-list (value box)))))
+                               (* *comment-box-margin* 2)))))
     (om-make-point
      contrained-width
      (max (if fit 0 (om-point-y size))


### PR DESCRIPTION
I think this prevents some unpleasantness when we change the font size for a comment, or load a patch when our preferences dictate a larger font size than the patch author's. Uses the width of the widest word as a minimum constraint.

NB: "split-sequence" is a useful function that is semi-standard, i guess: [cl-utilities](https://cliki.net/cl-utilities). It's in the LW package, and I'm exposing it as om-split-sequence ... just not sure if it's the appropriate location for om-api, probably not.


